### PR TITLE
Refactor setup.py and update artifact upload process

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Artifacts
+          name: Artifacts-${{ matrix.python-version }}
           path: ./dist/*
       - name: Publish package
         if: ${{ matrix.pypi }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -77,7 +77,7 @@ jobs:
           fi
           ls ./dist
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Artifacts
           path: ./dist/*

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -81,6 +81,8 @@ jobs:
         with:
           name: Artifacts-${{ matrix.python-version }}
           path: ./dist/*
+          overwrite: true
+          if--no-files-found: warn
       - name: Publish package
         if: ${{ matrix.pypi }}
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -82,9 +82,9 @@ jobs:
           name: Artifacts-${{ matrix.python-version }}
           path: ./dist/*
           overwrite: true
-          if--no-files-found: warn
+          if-no-files-found: warn
       - name: Publish package
-        if: ${{ matrix.pypi }}
+        if: ${{ matrix.pypi && github.ref == 'refs/heads/master' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ from setuptools import setup
 version = None
 
 try:
-    from importlib.metadata import version
+    from importlib.metadata import version as _version
+    version = _version
 except ImportError:
     from pkg_resources import VersionConflict, require
 

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,11 @@
     Learn more under: https://pyscaffold.org/
 """
 import sys
-from pkg_resources import VersionConflict, require
+from importlib.metadata import version
+
 from setuptools import setup
 
-try:
-    require("setuptools>=38.3")
-except VersionConflict:
+if version("setuptools") < "38.3":
     print("Error: version of setuptools is too old (<38.3)!")
     sys.exit(1)
 

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,31 @@
 # -*- coding: utf-8 -*-
 """
-    Setup file for datedown.
-    Use setup.cfg to configure your project.
+Setup file for datedown.
+Use setup.cfg to configure your project.
 
-    This file was generated with PyScaffold 3.3.
-    PyScaffold helps you to put up the scaffold of your new Python project.
-    Learn more under: https://pyscaffold.org/
+This file was generated with PyScaffold 3.3.
+PyScaffold helps you to put up the scaffold of your new Python project.
+Learn more under: https://pyscaffold.org/
 """
 import sys
-from importlib.metadata import version
+
 
 from setuptools import setup
 
-if version("setuptools") < "38.3":
+version = None
+
+try:
+    from importlib.metadata import version
+except ImportError:
+    from pkg_resources import VersionConflict, require
+
+    try:
+        require("setuptools>=38.3")
+    except VersionConflict:
+        print("Error: version of setuptools is too old (<38.3)!")
+        sys.exit(1)
+
+if version is not None and version("setuptools") < "38.3":
     print("Error: version of setuptools is too old (<38.3)!")
     sys.exit(1)
 


### PR DESCRIPTION
Refactor the version check in setup.py to use `importlib.metadata` instead of `pkg_resources`. This should work when `pkg_resources` is depreciated, while also  compatible with the old version.

Update the `upload-artifact` action to version 4.

Improve artifact naming to include the Python version.

Add options for overwriting existing artifacts and handling cases with no files found.

Refine the publish condition for the package.